### PR TITLE
add path to parsed api url to support api path-prefix

### DIFF
--- a/src/check-graylog2-stream/check-graylog2-stream.go
+++ b/src/check-graylog2-stream/check-graylog2-stream.go
@@ -79,7 +79,7 @@ func parseUrl(unparsed_url string) string {
     nagiosplugin.Exit(nagiosplugin.UNKNOWN, "Please give the API port number in the form http://hostname:port")
   }
 
-  connection_string := parsed_url.Scheme + "://" + parsed_url.Host
+  connection_string := parsed_url.Scheme + "://" + parsed_url.Host + parsed_url.Path
   return connection_string
 }
 


### PR DESCRIPTION
Graylog 2.1 suggests "/api" as path prefix. This commits add the path.
